### PR TITLE
Fixed overlapping text when seeking

### DIFF
--- a/xml/DialogSeekBar.xml
+++ b/xml/DialogSeekBar.xml
@@ -11,32 +11,6 @@
 			<top>150r</top>
 			<width>1140</width>
 			<visible>!VideoPlayer.Content(LiveTV) | [VideoPlayer.Content(LiveTV) + VideoPlayer.HasEpg]</visible>
-			<!--chapter-->
-			<control type="label" id="1">
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
-				<left>30</left>
-				<top>-8</top>
-				<width>1080</width>
-				<height>60</height>
-				<font>breadcrumb.secondary</font>
-				<align>center</align>
-				<aligny>center</aligny>
-				<label>$INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</label>
-				<visible>Player.Playing + !Player.IsTempo + !Player.DisplayAfterSeek</visible>
-			</control>
-			<!--chapter (paused)-->
-			<control type="label" id="1">
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
-				<left>30</left>
-				<top>-8</top>
-				<width>1080</width>
-				<height>60</height>
-				<font>breadcrumb.secondary</font>
-				<align>center</align>
-				<aligny>center</aligny>
-				<label>$LOCALIZE[31043] • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</label>
-				<visible>[Player.Paused + !Player.Caching] + !Player.Seeking + !Player.DisplayAfterSeek</visible>
-			</control>
 			<!--chapter (caching)-->
 			<control type="label" id="1">
 				<visible>!VideoPlayer.Content(LiveTV)</visible>
@@ -50,7 +24,6 @@
 				<label>$LOCALIZE[15107] $INFO[Player.CacheLevel]% • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</label>
 				<visible>[Player.Paused + Player.Caching] + !Player.Seeking</visible>
 			</control>
-			<!--chapter (seeking)-->
 			<control type="label" id="1">
 				<visible>!VideoPlayer.Content(LiveTV)</visible>
 				<left>30</left>
@@ -60,47 +33,7 @@
 				<font>breadcrumb.secondary</font>
 				<align>center</align>
 				<aligny>center</aligny>
-				<label>$LOCALIZE[31046] • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</label>
-				<visible>Player.Seeking</visible>
-			</control>
-			<!--chapter (final seek amount)-->
-			<control type="label" id="1">
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
-				<left>30</left>
-				<top>-8</top>
-				<width>1080</width>
-				<height>60</height>
-				<font>breadcrumb.secondary</font>
-				<align>center</align>
-				<aligny>center</aligny>
-				<label>$LOCALIZE[31046] $INFO[Player.SeekOffset] • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</label>
-				<visible>Player.DisplayAfterSeek + ![Player.Forwarding | Player.Rewinding | Player.IsTempo]</visible>
-			</control>
-			<!--chapter (fast forwarding)-->
-			<control type="label" id="1">
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
-				<left>30</left>
-				<top>-8</top>
-				<width>1080</width>
-				<height>60</height>
-				<font>breadcrumb.secondary</font>
-				<align>center</align>
-				<aligny>center</aligny>
-				<label>$VAR[Forwarding] • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</label>
-				<visible>Player.Forwarding | [Player.IsTempo + String.StartsWith(Player.PlaySpeed,1.)]</visible>
-			</control>
-			<!--chapter (rewinding)-->
-			<control type="label" id="1">
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
-				<left>30</left>
-				<top>-8</top>
-				<width>1080</width>
-				<height>60</height>
-				<font>breadcrumb.secondary</font>
-				<align>center</align>
-				<aligny>center</aligny>
-				<label>$VAR[Rewinding] • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</label>
-				<visible>Player.Rewinding | [Player.IsTempo + String.StartsWith(Player.PlaySpeed,0.)]</visible>
+				<label>$VAR[SeekLabel]</label>
 			</control>
 		</control>
 		<include>PVRChannelNumberInput</include>

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<includes>
+	<variable name="VideoPlayerForwardRewindVar">
+		<value condition="Player.Forwarding2x | Player.Rewinding2x">2x</value>
+		<value condition="Player.Forwarding4x | Player.Rewinding4x">4x</value>
+		<value condition="Player.Forwarding8x | Player.Rewinding8x">8x</value>
+		<value condition="Player.Forwarding16x | Player.Rewinding16x">16x</value>
+		<value condition="Player.Forwarding32x | Player.Rewinding32x">32x</value>
+	</variable>
+	<variable name="SeekLabel">
+		<value condition="Player.Paused">$LOCALIZE[112]</value>
+		<value condition="Player.Forwarding">$LOCALIZE[31044] $VAR[VideoPlayerForwardRewindVar]</value>
+		<value condition="Player.Rewinding">$LOCALIZE[31045] $VAR[VideoPlayerForwardRewindVar]</value>
+		<value condition="!String.IsEmpty(Player.SeekStepSize)">$LOCALIZE[31046] $INFO[Player.SeekStepSize] • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</value>
+		<value condition="!String.IsEmpty(Player.SeekOffset) + Player.DisplayAfterSeek">$LOCALIZE[31046] $INFO[Player.SeekOffset] • $INFO[player.chapter,$LOCALIZE[21396]  ]$INFO[player.chaptercount, / ]</value>
+	</variable>
+</includes>

--- a/xml/includes.xml
+++ b/xml/includes.xml
@@ -17,6 +17,7 @@
 	<include file="IncludesPVR.xml" />
 	<include file="IncludesWidgets.xml" />
 	<include file="IncludesDialogSelect.xml" />
+	<include file="Variables.xml" />
 	<constant name="FanartCrossfadeTime">500</constant>
 	<constant name="IconCrossfadeTime">400</constant>
 	<variable name="MusicInfoHeader">


### PR DESCRIPTION
With this I tried to fix the display error described in #10 

I tried to reverse engineer the estuary skin which is working and replicate the result in the skin. 

I tested it on my Kodi and i could not find any missing functionalities.